### PR TITLE
Add Apache-2.0 license metadata to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,11 +3,13 @@
 name = "common-expression-language"
 description = "Python bindings for the Common Expression Language (CEL)"
 readme = "README.md"
+license = "Apache-2.0"
 authors = [
     {name = "Brian Thorne", email = "brian@hardbyte.nz"}
 ]
 requires-python = ">=3.11"
 classifiers = [
+    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",


### PR DESCRIPTION
This PR adds explicit Apache-2.0 license metadata to the pyproject.toml file to ensure proper license information is exposed to downstream package managers and dependency scanning tools.

Changes:
- Added `license = "Apache-2.0"` field using SPDX identifier
- Added `"License :: OSI Approved :: Apache Software License"` classifier

This resolves issues where the package's license wasn't being properly detected by automated tools, requiring manual exceptions in dependency checks.