### PR TITLE
Prepare 0.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-08-19
+
+Adds the `sum` aggregation to the extended standard library, refreshes the locked
+Rust dependencies, and makes CI reproducible across Python 3.11 to 3.14.
+
 ### Added
 
 - `cel.stdlib`'s `core` library gains `sum`, completing the aggregation trio
@@ -14,14 +19,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [#14](https://github.com/hardbyte/python-common-expression-language/issues/14).
   It follows Kubernetes' CEL list library: `int`, `uint`, `double` and `duration`
   are supported; `sum([])` is `0`; booleans are rejected rather than counted as
-  `1`/`0`; numbers and durations cannot be mixed. As with every `cel.stdlib`
-  function, results cross the Python callback boundary, so a `uint` sum returns
-  an `int` and durations are microsecond-resolution — both now documented. As with the rest of the
+  `1`/`0`; and numbers cannot be mixed with durations. Like the rest of the
   extended stdlib it works in both call forms — `sum([1, 2, 3])` and
   `items.map(i, i.weight).sum()`.
-  `fold`/`reduce` remain unavailable: they need a parser-level comprehension
-  macro, which has to come from [cel-rust](https://github.com/cel-rust/cel-rust)
-  rather than this wrapper.
+- `fold`/`reduce` remain unavailable, and the reason is now documented in
+  `cel.stdlib` and the standard-library reference: a CEL function receives
+  evaluated arguments, whereas a fold needs its accumulator expression left
+  unevaluated, and cel-rust expands its comprehension macros from a fixed table
+  in the parser. They have to arrive in
+  [cel-rust](https://github.com/cel-rust/cel-rust) rather than in this wrapper.
+
+### Documented
+
+- The two lossy conversions at the Python callback boundary, which apply to every
+  `cel.stdlib` function rather than just the aggregations: a `uint` result returns
+  as an `int` (Python has a single integer type), so `sum([1u, 2u]) + 1u` has no
+  overload where the native `[1u, 2u][0] + 1u` works; and `duration` is carried by
+  `datetime.timedelta`, whose resolution is microseconds, so sub-microsecond
+  durations are rounded before a function sees them. Both behaviours are pinned by
+  tests.
 
 ### Updated
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "cel"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "cel 0.14.3",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cel"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Release prep for **0.8.0**, following the process in `docs/contributing.md`: version bump, changelog, then a GitHub release to trigger the PyPI publish.

`0.7.0` → `0.8.0` because `sum()` is a new user-facing function — additive, so a minor bump rather than a patch.

## Changes

- `Cargo.toml` version 0.7.0 → 0.8.0 (`pyproject.toml`'s version is dynamic via maturin, so this is the single source), with `Cargo.lock` refreshed to match.
- `CHANGELOG.md`: the `Unreleased` notes become a dated `[0.8.0] - 2026-08-19` section — the `sum` aggregation, the newly documented Python callback-boundary conversions (`uint` → `int`, microsecond durations), the refreshed Rust lockfile (cel 0.14.3, PyO3 0.29.2), and the CI work (Python 3.13/3.14, committed `uv.lock`, ruff pin, `safety scan`, `claude-code-action@v1`).

No code changes.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, `ruff format --check`, `ruff check`, `mypy python/cel`, and the full suite (474 passed, 1 skipped, 6 xfailed). Confirmed the built wheel reports `0.8.0`.

After this merges I'll tag `v0.8.0` on `main`, which is what triggers the release job's PyPI upload.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RPBDyJWe8968v8ErH2hLot)_