### PR TITLE
Publish to PyPI with trusted publishing and create the GitHub release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,14 +212,51 @@ jobs:
     runs-on: ubuntu-latest
     if: "startsWith(github.ref, 'refs/tags/')"
     needs: [linux, windows, macos, sdist]
+    environment:
+      name: pypi
+      url: https://pypi.org/p/common-expression-language
     permissions:
+      # id-token: write mints the OIDC token PyPI trusted publishing exchanges
+      # for a short-lived upload token, so no PyPI API token is stored here.
       id-token: write
+      # contents: write lets the last step create the GitHub release for the tag.
+      contents: write
     steps:
-      - uses: actions/download-artifact@v5
-      - name: Publish to PyPI
-        uses: PyO3/maturin-action@v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+      - uses: actions/checkout@v5
+
+      - name: Collect wheels and sdist
+        uses: actions/download-artifact@v5
         with:
-          command: upload
-          args: --non-interactive --skip-existing wheels-*/*
+          pattern: wheels-*
+          merge-multiple: true
+          path: dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            echo "Release $GITHUB_REF_NAME already exists; refreshing its assets."
+            gh release upload "$GITHUB_REF_NAME" dist/* --clobber
+            exit 0
+          fi
+          version="${GITHUB_REF_NAME#v}"
+          awk -v v="$version" '
+            $0 ~ "^## \\[" v "\\]" { found = 1; next }
+            found && /^## \[/ { exit }
+            found { print }
+          ' CHANGELOG.md > notes.md
+          if [ -s notes.md ]; then
+            gh release create "$GITHUB_REF_NAME" --verify-tag \
+              --title "$GITHUB_REF_NAME" --notes-file notes.md dist/*
+          else
+            echo "::warning::No CHANGELOG section for $version; using generated notes."
+            gh release create "$GITHUB_REF_NAME" --verify-tag \
+              --title "$GITHUB_REF_NAME" --generate-notes dist/*
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,14 @@ jobs:
           if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
             echo "Release $GITHUB_REF_NAME already exists; refreshing its assets."
             gh release upload "$GITHUB_REF_NAME" dist/* --clobber
+            # `gh release create` with assets creates a draft, uploads, then publishes,
+            # and deletes the draft if an upload fails. A job that dies before that
+            # cleanup runs leaves a draft behind, so publish it rather than exiting
+            # with the release invisible.
+            if [ "$(gh release view "$GITHUB_REF_NAME" --json isDraft --jq .isDraft)" = "true" ]; then
+              echo "Release was left as a draft by an earlier run; publishing it."
+              gh release edit "$GITHUB_REF_NAME" --draft=false
+            fi
             exit 0
           fi
           version="${GITHUB_REF_NAME#v}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Updated
+
+- Releases publish to PyPI with
+  [trusted publishing](https://docs.pypi.org/trusted-publishers/) instead of a
+  stored `PYPI_API_TOKEN`: the release job exchanges a short-lived GitHub OIDC
+  token for the upload credential, so no long-lived PyPI token is kept in repository
+  secrets. The job runs in a `pypi` environment, which the trusted publisher on
+  PyPI is configured against.
+- The release job now also creates the GitHub release for the pushed tag, using the
+  matching `CHANGELOG.md` section as the release notes and attaching the wheels and
+  sdist. Pushing a tag previously published to PyPI but left no GitHub release
+  behind.
+
 ## [0.8.0] - 2026-08-19
 
 Adds the `sum` aggregation to the extended standard library, refreshes the locked

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -311,7 +311,26 @@ uv run pytest --profile tests/test_performance.py
 
 ## Release Process
 
-1. **Version Bump** - Update version in `pyproject.toml`
-2. **Changelog** - Document changes in `CHANGELOG.md`
-3. **Release** - Create a release in GitHub to trigger publishing to PyPI
+1. **Version bump** - update `version` in `Cargo.toml`. `pyproject.toml` takes its
+   version from there via maturin, so `Cargo.toml` is the single source; run
+   `cargo check` afterwards so `Cargo.lock` picks up the new version.
+2. **Changelog** - turn the `Unreleased` section of `CHANGELOG.md` into a dated
+   `## [X.Y.Z] - YYYY-MM-DD` section. The release job uses that section verbatim as
+   the GitHub release notes, so it is worth writing well.
+3. **Tag** - merge those changes, then tag the merge commit and push the tag:
+
+   ```bash
+   git tag -a vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z
+   ```
+
+Pushing the tag runs the full test matrix, builds wheels for every supported
+platform plus the sdist, uploads them to PyPI, and creates the GitHub release for
+the tag with the changelog section as its notes and the built artifacts attached.
+Pushing the tag is the only manual step - there is no "draft a release" click.
+
+PyPI uploads use [trusted publishing](https://docs.pypi.org/trusted-publishers/):
+the `release` job mints a short-lived OIDC token from GitHub rather than using a
+stored API token. The publisher is registered on PyPI against this repository, the
+`ci.yml` workflow and the `pypi` environment, so renaming the workflow file or the
+environment means updating the trusted publisher on PyPI as well.
 


### PR DESCRIPTION
Two changes to the `release` job in `ci.yml`, plus the docs that describe it.

## Trusted publishing

`PYO3/maturin-action` with `MATURIN_PYPI_TOKEN` → `pypa/gh-action-pypi-publish`, which exchanges the job's short-lived GitHub OIDC token for a PyPI upload credential. The job already declared `id-token: write` without using it; now that permission does something and no long-lived PyPI token is stored in repository secrets.

* The job runs in a `pypi` environment (`https://pypi.org/p/common-expression-language`), which is what the trusted publisher is scoped against and gives you somewhere to add an approval gate later.
* Artifacts are collected into `dist/` via `pattern: wheels-*` + `merge-multiple: true`, since the action publishes `dist/` by default. `skip-existing: true` preserves the old `--skip-existing` behaviour on re-runs.

## GitHub release creation

Pushing `v0.8.0` published to PyPI but left no GitHub release, because a tag and a release are separate objects and nothing in the repo created the latter. The job now does, from the tag:

* Release notes come from the matching `## [X.Y.Z]` section of `CHANGELOG.md`, extracted with awk. Verified against the real file: 46 lines for `0.8.0`, empty for a version with no section — in which case it warns and falls back to `--generate-notes` rather than failing a release that has already published to PyPI.
* Wheels and sdist are attached, and `--verify-tag` refuses to invent a tag that doesn't exist.
* If the release already exists (re-run of a tag), it refreshes the assets and exits instead of erroring.

This needs `contents: write` on the job, alongside `id-token: write`.

## Docs

`docs/contributing.md`'s release process said to bump the version in `pyproject.toml` — the version actually lives in `Cargo.toml`, with `pyproject.toml` deriving it through maturin. Corrected, and the tag-driven flow, the trusted-publishing setup, and the workflow/environment names the publisher is tied to are now written down.

## Required one-time setup before the next tag

This PR cannot configure PyPI, so the next release will fail to upload unless this is done first:

1. PyPI → `common-expression-language` → Manage → Publishing → **Add a new pending/trusted publisher** (GitHub):
   * Owner `hardbyte`, repository `python-common-expression-language`
   * Workflow name `ci.yml`
   * Environment `pypi`
2. Repo → Settings → Environments → create `pypi` (optionally restrict it to tag pushes).
3. Once a release has published successfully, delete the now-unused `PYPI_API_TOKEN` secret.

All three values must match the workflow exactly — renaming `ci.yml` or the environment means updating the publisher on PyPI too.

## Verification

The workflow parses (`yaml.safe_load`) with the expected permissions, environment and step order; the awk extraction was exercised against `CHANGELOG.md` for both the present and missing-section cases; docs tests, `ruff format --check` and `ruff check` pass. The release path itself can only be exercised by a real tag push, so `0.9.0` will be its first live run — the `skip-existing`, `--verify-tag` and already-exists guards are there so a partial failure is recoverable.

Note that `v0.8.0` itself still has no GitHub release; this automation only applies from the next tag. Happy to write the notes for a backfilled `v0.8.0` release if you create it (the tag push I attempted was blocked — this session's credentials can push branches but not tags).

---
_Generated by [Claude Code](https://claude.ai/code/session_01RPBDyJWe8968v8ErH2hLot)_