### PR TITLE
Prepare 0.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-09-09
+
+Upgrades to cel-rust 0.14.5, which brings native `type()`, range-checked
+`int()`/`uint()` conversions and, notably, rejection of CEL reserved words as
+identifiers. Also the first release published through PyPI trusted publishing,
+with the GitHub release created automatically from this section.
+
 ### Changed
 
 - **CEL reserved words are now rejected as identifiers.** cel-rust 0.14.4 enforces the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "cel"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "cel 0.14.5",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cel"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Bumps `Cargo.toml` to 0.9.0 (`Cargo.lock` follows) and dates the CHANGELOG section.

Release notes extraction verified locally: the release job's `awk` pulls 59 lines for `## [0.9.0]`, starting at the summary paragraph and ending before `## [0.8.0]`.

After merging, the tag push is the manual step:

```bash
git fetch origin && git checkout main && git pull --ff-only
git tag -a v0.9.0 -m "v0.9.0" && git push origin v0.9.0
```

This is the first release through the trusted-publishing + auto-GitHub-release job (#41), so watch the `Release` job. `PYPI_API_TOKEN` can be deleted from repo secrets once it succeeds.
